### PR TITLE
Let's not mutate the global window.navigator object

### DIFF
--- a/build/mp3Recorder.js
+++ b/build/mp3Recorder.js
@@ -60,11 +60,6 @@ var Mp3Recorder = function () {
       this.microphone.connect(this.processor);
       this.processor.connect(this.context.destination);
     }
-  }, {
-    key: 'setUserMedia',
-    value: function setUserMedia() {
-      navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
-    }
 
     // Function for kicking off recording once the button is pressed.
 
@@ -73,9 +68,9 @@ var Mp3Recorder = function () {
     value: function start(onSuccess, onError) {
       var _this = this;
 
-      this.setUserMedia();
+      var getUserMedia = (window.navigator.getUserMedia || window.navigator.webkitGetUserMedia || window.navigator.mozGetUserMedia).bind(window.navigator);
 
-      navigator.getUserMedia({ audio: true }, function (stream) {
+      getUserMedia({ audio: true }, function (stream) {
         _this.beginRecording(stream);
 
         if (onSuccess && typeof onSuccess === 'function') {

--- a/src/mp3Recorder.js
+++ b/src/mp3Recorder.js
@@ -47,18 +47,11 @@ class Mp3Recorder {
     this.processor.connect(this.context.destination);
   }
 
-  setUserMedia() {
-    navigator.getUserMedia = navigator.getUserMedia ||
-                          navigator.webkitGetUserMedia ||
-                          navigator.mozGetUserMedia ||
-                          navigator.msGetUserMedia
-  }
-
   // Function for kicking off recording once the button is pressed.
   start(onSuccess, onError) {
-    this.setUserMedia()
+    const getUserMedia = (window.navigator.getUserMedia || window.navigator.webkitGetUserMedia || window.navigator.mozGetUserMedia).bind(window.navigator);
 
-    navigator.getUserMedia({ audio: true }, (stream) => {
+    getUserMedia({ audio: true }, (stream) => {
       this.beginRecording(stream)
 
       if (onSuccess && typeof onSuccess === 'function') {


### PR DESCRIPTION
The issue with mutating the global is that browsers who don't support `getUserMedia` (like Safari) get some funkyness associated with them when calling/testing `window.navigator.getUserMedia`.

And it's probably a good practice.

Note: the reason the `.bind(window.navigator)` is included here is [explained here](http://stackoverflow.com/a/27552062/680394).

To test:
1. clone this repo and check out this branch
2. run `$ npm link`
3. in your rise-frontend project, run `$ npm link @articulate/rise-mp3-recorder`
4. start up your authoring bundles
5. [x] can still record audio in Chrome
